### PR TITLE
Add the ORC writer

### DIFF
--- a/_posts/2021-04-26-4.0.0-release.md
+++ b/_posts/2021-04-26-4.0.0-release.md
@@ -68,7 +68,7 @@ The Arrow C++ library now includes a [`vcpkg.json`](https://github.com/apache/ar
 
 * Parquet library version will now be updated with each release.
 * Parquet DECIMAL statistics where previously calculated incorrectly, this has now been fixed.
-* The Arrow C++ library now includes an ORC writer. 
+* The Arrow C++ library will now include an ORC writer. Hence it is possible to read and write ORC files in the Arrow C++ library. 
 
 ## C# notes
 

--- a/_posts/2021-04-26-4.0.0-release.md
+++ b/_posts/2021-04-26-4.0.0-release.md
@@ -68,6 +68,7 @@ The Arrow C++ library now includes a [`vcpkg.json`](https://github.com/apache/ar
 
 * Parquet library version will now be updated with each release.
 * Parquet DECIMAL statistics where previously calculated incorrectly, this has now been fixed.
+* The Arrow C++ library now includes an ORC writer. 
 
 ## C# notes
 
@@ -85,6 +86,8 @@ Java now supports IPC buffer compression (ZSTD is recommended as the current per
 ## Python notes
 - Limited support for writing out CSV files (only types that have cast implementation to String) are now available.
 - Writing parquet list types now has the option of enabling the canonical group naming according to the Parquet specification.
+- The ORC Writer is now available.
+
 ## R notes
 
 The `dplyr` interface to Arrow data gained many new features in this release, including support for `mutate()`, `relocate()`, and more. You can also call in `filter()` or `mutate()` over 100 functions supported by the Arrow C++ library, and many string functions are available both by their base R (`grepl()`, `gsub()`, etc.) and `stringr` (`str_detect()`, `str_replace()`) spellings.


### PR DESCRIPTION
I included some description of the ORC writer in C++ and Python.  I need to work on updating the documentation in both C++ and Python as well.